### PR TITLE
Add limit-width option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ lua require('buffertag').setup({
     -- accepts any border options that `nvim_open_win` accepts.
     -- see ":help vim.api.nvim_open_win"
     border = "none",
+    -- By default if the buffer name is too wide for the pane it's in, it will
+    -- display and overlap the pane. By setting this to true, the buffer name will
+    -- be truncated to fit within the pane, ensuring the floating window does not
+    -- overlap any other panes.
+    limit_width = false,
 })
 ```
 

--- a/lua/buffertag/config.lua
+++ b/lua/buffertag/config.lua
@@ -1,7 +1,8 @@
 local M = {}
-    
+
 M.config = {
-    border = 'none'
+    border = 'none',
+    limit_width = false,
 }
 
 return M

--- a/lua/buffertag/init.lua
+++ b/lua/buffertag/init.lua
@@ -35,16 +35,35 @@ function create_tag_float(parent_win)
         vim.api.nvim_err_writeln("details_popup: could not create details buffer")
         return nil
     end
+
+    local popup_text = buf_name
+    -- By default, the popup width is the same as the length of the buffer text we want to show.
+    local popup_width = #buf_name
+
+    local window_width = vim.api.nvim_win_get_width(parent_win)
+    -- Subtract 5 here to give the window a bit of padding - otherwise it can
+    -- look a bit squashed as technically the text fits, but it's right up to
+    -- the very edge of the pane and doesn't look great
+    local window_width_with_padding = window_width - 5;
+
+  if c.config.limit_width and popup_width > window_width_with_padding then
+      popup_width = window_width_with_padding
+      -- Take the last X characters of the buf_name, where X is the available width.
+      -- e.g. if the name is foo/bar/baz.js, and the width is 6, this will return baz.js
+      popup_text = string.sub(popup_text, #buf_name - popup_width + 1, #buf_name)
+    end
+
+
     vim.api.nvim_buf_set_option(buf, 'bufhidden', 'delete')
     vim.api.nvim_buf_set_option(buf, 'modifiable', true)
-    vim.api.nvim_buf_set_lines(buf, 0, 0, false, {buf_name})
+    vim.api.nvim_buf_set_lines(buf, 0, 0, false, {popup_text})
     vim.api.nvim_buf_set_option(buf, 'modifiable', false)
-    
+
     local popup_conf = {
         relative = "win",
         anchor = "NE",
         win = parent_win,
-        width = #buf_name,
+        width = popup_width,
         height = 1,
         focusable = false,
         zindex = 1,


### PR DESCRIPTION
When working on very narrow windows I noticed that if the buffer name
was too long, it would cause a floating window that would overflow out
of the pane it was representing. This may be desirable for some, but I'd
rather limit it to the width of the buffer.

That is what the new `limit-width` option provides; when enabled, should
the buffer text not fit in the available width, it will truncate it to
do so.

I can see future expansions to this if you think they are appropriate:

1. don't truncate the text, but have it wrap over multiple lines
2. allow the user to customise more how the buffer name is truncated -
   custom replacements, perhaps?

Please let me know what you think, and if this is something you're happy
to land. Thanks!