### PR TITLE
feat: add config option to enable/disable on load

### DIFF
--- a/lua/buffertag/config.lua
+++ b/lua/buffertag/config.lua
@@ -3,6 +3,7 @@ local M = {}
 M.config = {
     border = 'none',
     limit_width = false,
+    start_enabled = true,
 }
 
 return M

--- a/lua/buffertag/init.lua
+++ b/lua/buffertag/init.lua
@@ -141,7 +141,9 @@ function M.setup(config)
     })
 
     -- toggle it on.
-    M.toggle()
+    if c.config.start_enabled then
+        M.toggle()
+    end
 end
 
 return M


### PR DESCRIPTION
Adds a configuration value `enabled_on_startup` to control whether the plugin is enabled or disabled
when loaded.

# Usecase

If only showing the buffertags sometimes, this is cleaner than a `:BuffertagToggle` on startup.
